### PR TITLE
Move footer line to the end of file

### DIFF
--- a/gotest-ts.el
+++ b/gotest-ts.el
@@ -39,7 +39,6 @@
 ;;
 ;;; Code:
 
-;;; gotest-ts.el ends here
 (require 'gotest)
 (require 'treesit)
 
@@ -79,3 +78,5 @@ Default is \"name\"."
       (go-test--go-test (concat "-run " gotest " .")))))
 
 (provide 'gotest-ts)
+
+;;; gotest-ts.el ends here


### PR DESCRIPTION
Previously, there was an `native-compiler-error-empty-byte` error when doing native compilation.

https://hydra.nix-community.org/build/2447857/nixlog/2