### PR TITLE
Quoting the test regex

### DIFF
--- a/gotest-ts.el
+++ b/gotest-ts.el
@@ -189,7 +189,7 @@ This command intelligently determines what test to run based on the cursor posit
   (condition-case err
       (let ((test-pattern (gotest-ts--build-test-pattern)))
         (message "Running test: %s" test-pattern)
-        (go-test--go-test (concat "-run " test-pattern " .")))
+        (go-test--go-test (concat "-run '" test-pattern "' .")))
 
     (error
      (message "Error running test: %s" (error-message-string err)))))
@@ -207,7 +207,7 @@ This command intelligently determines what test to run based on the cursor posit
 
     (let ((test-pattern (format "^%s$" func-name)))
       (message "Running test function: %s" test-pattern)
-      (go-test--go-test (concat "-run " test-pattern " .")))))
+      (go-test--go-test (concat "-run '" test-pattern "' .")))))
 
 ;;;###autoload
 (defun gotest-ts-show-test-info ()


### PR DESCRIPTION
My compilation buffer has Fish running, and it didn't like the unquoted regex, especially the `$`. So adding quotes around the regex solves this issue.

From:
```
go test -run ^TestSomething/SpecificTest$ .
fish: Expected a variable name after this $.
go test -run ^TestSomething/SpecificTest$ .
                                        ^
```

to:
```
go test -run '^TestSomething/SpecificTest$' .
```